### PR TITLE
Little change so mijn.groept.be, kuloket, etc. work

### DIFF
--- a/lib/login.js
+++ b/lib/login.js
@@ -1,7 +1,7 @@
 // Mapping between login page identifier and the url
 var urls = {
 	'netlogin':		/^https:\/\/netlogin\.kuleuven\.be\/cgi-bin\/wayf2\.pl/,
-	'kuleuven':		/^https:\/\/idp\.kuleuven\.be\/idp\/profile\/SAML2\/POST\/SSO\?execution=e[0-9]*s1$/,
+	'kuleuven':		/^https:\/\/idp\.kuleuven\.be\/idp\/profile\/SAML2\/(Redirect|POST)\/SSO\?execution=e[0-9]*s1$/,
 	'groept':		/^https:\/\/idp\.groept\.be\/idp\/view\/login\.htm$/,
 	'hubrussel':	/^https:\/\/idp\.hubrussel\.be\/idp\/view\/login\.htm$/,
 	'katho':		/^https:\/\/idp\.katho\.be\/idp\/view\/login\.htm$/,


### PR DESCRIPTION
line 4: replaced POST with (POST|Redirect). POST is only in the toledo login URL, Redirect is used by the others (kuloket etc.).

(Should have tested my previous pull a bit better, sorry!)